### PR TITLE
Move SIP-4 to Withdrawn

### DIFF
--- a/SIPS/sip-4.md
+++ b/SIPS/sip-4.md
@@ -1,7 +1,7 @@
 ---
 sip: 4
 title: Merging of snap.manifest.json and package.json
-status: Review
+status: Withdrawn
 discussions-to: https://github.com/MetaMask/SIPs/discussions/51
 author: Olaf Tomalka (@ritave)
 created: 2022-09-23


### PR DESCRIPTION
The MetaMask team decided to stay with `snap.manifest.json` for the for now, and so this SIP is being moved to Withdrawn.

Should we want to revisit this decision in the future, a new SIP will be created.