### PR TITLE
Move SIP-2 to Withdrawn

### DIFF
--- a/SIPS/sip-2.md
+++ b/SIPS/sip-2.md
@@ -1,7 +1,7 @@
 ---
 sip: 2
 title: Snap Keyrings
-status: Implementation
+status: Withdrawn
 discussions-to: https://github.com/MetaMask/SSIPs/discussions/10
 author: Olaf Tomalka (@ritave), Muji (@tmpfs)
 created: 2022-06-10


### PR DESCRIPTION
Learnings from implementing are being used to implement a better API than SIP-2, but not the same one.

The new API shall have a new SIP for it.