### PR TITLE
Updated list of active editors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Current SIP editors
-SIPS/ @hmalik88 @Montoya @rekmarks @ritave
+SIPS/ @hmalik88 @Montoya @ritave @ziad-saab

--- a/SIPS/sip-1.md
+++ b/SIPS/sip-1.md
@@ -91,9 +91,9 @@ The role of SIP repository editors is to enforce the inclusion process. They do 
 The current SIP editors, sorted alphabetically, are:
 
 - Christian Montoya ([@Montoya](https://github.com/Montoya))
-- Erik Marks ([@rekmarks](https://github.com/rekmarks))
 - Hassan Malik ([@hmalik88](https://github.com/hmalik88))
 - Olaf Tomalka ([@ritave](https://github.com/ritave))
+- Ziad Saab ([@ziad-saab](https://github.com/ziad-saab))
 
 At least one of the editors has to approve any incoming pull requests that update files in the [SIPs folder](./).
 


### PR DESCRIPTION
- @rekmarks has moved into a product role, away from technical one.
- @ziad-saab has been a public technical of Snaps as a devrel.