### PR TITLE
Update codeowners to include snaps-devs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # Current SIP editors
-SIPS/ @hmalik88 @Montoya @ritave @ziad-saab
+* @metamask/snaps-devs
+SIPS/ @Montoya @ziad-saab @metamask/snaps-devs


### PR DESCRIPTION
This adds snaps-devs to the codeowners list.