### PR TITLE
Make Github account validation work as described in author spec

### DIFF
--- a/tools/validate/src/rules/preamble-data.ts
+++ b/tools/validate/src/rules/preamble-data.ts
@@ -53,7 +53,7 @@ const author = () =>
       if (match === null) {
         return "is malformed";
       }
-      if (match[2] !== undefined) {
+      if (match[1] !== undefined || match[2] !== undefined) {
         hasGithub = true;
       }
     }


### PR DESCRIPTION
The spec defines an author as:

`Name Surname <email> (@github-username)`, e.g.: `John F. Kowalsky <john.kowalsky@domain.com> (@kowalsky)`

However the rule to determine the github user account only works with authors that do not have an email field.