### PR TITLE
Add SIP-20 (External Data and Events)

### DIFF
--- a/SIPS/sip-20.md
+++ b/SIPS/sip-20.md
@@ -1,6 +1,6 @@
 ---
 sip: 20
-title: External data (WebSockets and other custom data or events)
+title: External data entry point
 status: Draft
 author: David Drazic (@david0xd)
 created: 2023-12-15
@@ -8,24 +8,15 @@ created: 2023-12-15
 
 ## Abstract
 
-This SIP proposes changes to the Snap manifest and additional request handler that allows Snap developers to implement
-functionality that is invoked when external data events occur. This proposal outlines some of the details around this feature.
+This SIP proposes a new permission that enables Snaps to receive data from external sources.
 
-The purpose of the initial version of this SIP is to provide support for WebSockets.
-This SIP only proposes one-way communication.
-This SIP is made with extensibility in mind and can be updated to handle more external data sources (like blockchain
-events, etc.).
+In the initial version, this SIP proposes support for WebSockets, but it can be extended to support other data sources like blockchain events in the future.
+The Snap can specify the external data source in the Snap manifest. The client then connects to the external data source and sends the data to the Snap.
+The Snap can then do whatever it wants with the data. This initial version only supports one-way communication from the external source to the Snap. The Snap can't send any data back to the external source.
 
 ## Motivation
 
-Snaps are currently isolated from outside events and rely on combination of user actions or CRON jobs and fetch
-endowments in order to receive extra information from independent remote sources distributed over the internet.
-
-This proposal provides an improvement that enables one way communication between a Snap and an external data or event
-source.
-The idea is that the external event source sends arbitrary data to the specific controller with listener running
-inside a wallet. The controller then sends the data to the Snap which runs execution of this feature specific RPC
-request handler.
+Snaps are currently limited in their ability to receive data from external sources: Either they have to rely on user actions or cron jobs to fetch data, so they can't react to events in real time. Snaps also cannot use WebSocket connections to receive data from external sources, and are limited to HTTP requests.
 
 ## Specification
 
@@ -33,12 +24,46 @@ request handler.
 
 ### Language
 
-The key words "MUST", "MUST NOT", "SHOULD", "RECOMMENDED" and "MAY" written in uppercase in this document are to be
-interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt)
+The key words "MUST", "MUST NOT", "SHOULD", "RECOMMENDED" and "MAY" written in uppercase in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 ### Snap Manifest
 
-This SIP specifies a permission named `endowment:external-data`.
+This SIP introduces a new permission named `endowment:external-data`.
+
+```typescript
+/**
+ * A WebSocket connection as specified in the Snap manifest.
+ *
+ * @property type - The type of connection. Currently, only WebSockets are
+ * supported.
+ * @property url - The URL to connect to. This must be a valid WebSocket URL,
+ * starting with `wss://`. URLs starting with `ws://` are not allowed.
+ * @property dataType - The type of data expected from the WebSocket. If this
+ * field is omitted, text is assumed.
+ */
+type WebSocketConnection = {
+  type: 'websocket';
+  url: string;
+  dataType?: 'text' | 'binary';
+};
+
+/**
+ * An external data connection as specified in the Snap manifest.
+ *
+ * Currently, only {@link WebSocketConnection} is supported.
+ */
+type ExternalDataConnection = WebSocketConnection;
+
+/**
+ * External data connections as specified in the Snap manifest.
+ *
+ * This is the value of the `endowment:external-data` field in the Snap
+ * manifest.
+ */
+type ExternalData = ExternalDataConnection[];
+```
+
+#### Example
 
 The new field can be specified as follows in a `snap.manifest.json` file:
 
@@ -70,30 +95,76 @@ The new field can be specified as follows in a `snap.manifest.json` file:
 
 ### Permission caveats
 
-Each caveat object MUST have `type` property that SHOULD be `websocket` or `blockchain`.
-If the `type` is `websocket`then the caveat MUST have `url` and `dataType` properties.
+Each caveat object MUST have `type` property that SHOULD be `websocket`.
+The caveat MUST have `url` and `dataType` properties.
 The `url` MUST be string.
 The `dataType` MUST be string that MUST be `"binary"` or `"text"`.
-The `chainId` MUST be string that represents supported blockchain.
-The `events` SHOULD be an array of strings which represent name of the events for subscription.
 
 - `type` property represents the type of data source.
 - `url` is the WebSocket URL.
 - `dataType` is type of data that WebSocket returns.
-- `chainId` is the blockchain ID.
-- `events` is the array of events to subscribe.
 
-The caveats MUST NOT have duplicate objects with the same `url` or `chainId` properties.
+The caveats MUST NOT have duplicate objects with the same `url` properties.
 
 The `url` MUST start with `wss://` which is a protocol indicator for secure WebSocket connection.
 
-### Snap implementation (request handler)
+### Snap implementation
 
-This SIP proposes the following RPC request handler to execute implemented functionality for external data events:
+This SIP introduces a new `onExternalData` function export that MAY be implemented by the Snap. The function is called every time the WebSocket client receives some data. The function SHOULD accept an object parameter that MUST have `data`, `type` and `source` properties.
+The parameters represent the following:
+- `data`: An object that represents the data that was received. Depending on the `data.type`, this SHOULD contain a `message` property, which SHOULD be either a `string` or an `ArrayBuffer`.
+- `type`: The type of the external data source. For this SIP, this SHOULD always be `websocket`.
+- `source`: The URL that the message was sent from. Snaps can use this to differentiate between different endpoints. This SHOULD be the exact same URL as specified in manifest.
 
-#### OnExternalDataHandler
+The specification of types of `onExternalData` and its parameters:
 
-Example:
+```typescript
+/**
+ * A text message received from a WebSocket.
+ *
+ * @property type - The type of the message.
+ * @property message - The message as a string.
+ */
+type WebSocketTextMessage = {
+  type: 'text';
+  message: string;
+};
+/**
+ * A binary message received from a WebSocket.
+ *
+ * @property type - The type of the message.
+ * @property message - The message as an ArrayBuffer.
+ */
+type WebSocketBinaryMessage = {
+  type: 'binary';
+  message: ArrayBuffer;
+};
+/**
+ * A message received from a WebSocket.
+ *
+ * @property type - The type of the message.
+ * @property message - The message as a string or an ArrayBuffer, depending on
+ * the type.
+ */
+type WebSocketData = {
+  type: 'websocket';
+  data: WebSocketTextMessage | WebSocketBinaryMessage;
+};
+/**
+ * The data received from an external source.
+ *
+ * @property type - The type of the external data source.
+ * @property data - The data received from the external data source.
+ */
+type ExternalData = WebSocketData;
+type OnExternalDataHandlerArgs = ExternalData & {
+  source: string;
+};
+type OnExternalDataHandler = (args: OnExternalDataHandlerArgs) => Promise<void>;
+```
+
+#### Example
+
 ```typescript
 import { OnExternalDataHandler } from '@metamask/snaps-types';
 import { assert } from '@metamask/utils';
@@ -106,49 +177,6 @@ export const onExternalData: OnExternalDataHandler = ({ id, type, data, source }
   const json = JSON.parse(data.message);
 };
 ```
-
-Snap that wants to use external data sources MUST have `onExternalData` function export.
-
-Exported function SHOULD accept an object parameter that MAY have `id`, `type`, `data` and `source` properties.
-
-This export SHOULD be called every time the WebSocket client or Blockchain event listener receives some data or event.
-
-The parameters represent the following:
-- `id`: Unique ID of an event generated internally on the controller side. This can be used for tracking each event
-  in case of storage needs or debugging. The `id` MUST be unique string.
-- `data`: SHOULD be the raw message that the WebSocket client received. Depending on the `type`, this SHOULD be
-  either a `string` or an `ArrayBuffer`.
-- `type`: The type of the message that was sent. This SHOULD be either `text` or `binary`.
-- `source`: The URL that the message was sent from. Snaps can use this to differentiate between different endpoints.
-  This SHOULD be the exact same URL as specified in manifest.
-
-The RECOMMENDED specification of types of `OnExternalDataHandler` and its parameters:
-
-```typescript
-type WebSocketMessage = {
-  type: 'text';
-  message: string;
-} | {
-  type: 'binary';
-  message: ArrayBuffer;
-};
-
-type WebSocketData = {
-  type: 'websocket';
-  data: WebSocketMessage;
-};
-
-type ExternalData = WebSocketData;
-
-type OnExternalDataHandlerArgs = ExternalData & {
-  source: string;
-};
-
-type OnExternalDataHandler = (args: OnExternalDataHandlerArgs) => Promise<void>;
-```
-
-The specification MAY be extended or changed depending on a type of data or event sources and their implementation
-needs.
 
 ## Copyright
 

--- a/SIPS/sip-20.md
+++ b/SIPS/sip-20.md
@@ -1,0 +1,155 @@
+---
+sip: 20
+title: External data (WebSockets and other custom data or events)
+status: Draft
+author: David Drazic (@david0xd)
+created: 2023-12-15
+---
+
+## Abstract
+
+This SIP proposes changes to the Snap manifest and additional request handler that allows Snap developers to implement
+functionality that is invoked when external data events occur. This proposal outlines some of the details around this feature.
+
+The purpose of the initial version of this SIP is to provide support for WebSockets.
+This SIP only proposes one-way communication.
+This SIP is made with extensibility in mind and can be updated to handle more external data sources (like blockchain
+events, etc.).
+
+## Motivation
+
+Snaps are currently isolated from outside events and rely on combination of user actions or CRON jobs and fetch
+endowments in order to receive extra information from independent remote sources distributed over the internet.
+
+This proposal provides an improvement that enables one way communication between a Snap and an external data or event
+source.
+The idea is that the external event source sends arbitrary data to the specific controller with listener running
+inside a wallet. The controller then sends the data to the Snap which runs execution of this feature specific RPC
+request handler.
+
+## Specification
+
+> Formal specifications are written in Typescript.
+
+### Language
+
+The key words "MUST", "MUST NOT", "SHOULD", "RECOMMENDED" and "MAY" written in uppercase in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt)
+
+### Snap Manifest
+
+This SIP specifies a permission named `endowment:external-data`.
+
+The new field can be specified as follows in a `snap.manifest.json` file:
+
+```json
+{
+  "initialPermissions": {
+    "endowment:external-data": [
+      {
+        "type": "websocket",
+        "url": "wss://example.com/binary/endpoint",
+        "dataType": "binary"
+      },
+      {
+        "type": "websocket",
+        "url": "wss://example.com/text/endpoint",
+        "dataType": "text"
+      },
+      {
+        "type": "blockchain",
+        "chainId": "eip155:1",
+        "events": [
+          "block"
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Permission caveats
+
+Each caveat object MUST have `type` property that SHOULD be `websocket` or `blockchain`.
+If the `type` is `websocket`then the caveat MUST have `url` and `dataType` properties.
+The `url` MUST be string.
+The `dataType` MUST be string that MUST be `"binary"` or `"text"`.
+The `chainId` MUST be string that represents supported blockchain.
+The `events` SHOULD be an array of strings which represent name of the events for subscription.
+
+- `type` property represents the type of data source.
+- `url` is the WebSocket URL.
+- `dataType` is type of data that WebSocket returns.
+- `chainId` is the blockchain ID.
+- `events` is the array of events to subscribe.
+
+The caveats MUST NOT have duplicate objects with the same `url` or `chainId` properties.
+
+The `url` MUST start with `wss://` which is a protocol indicator for secure WebSocket connection.
+
+### Snap implementation (request handler)
+
+This SIP proposes the following RPC request handler to execute implemented functionality for external data events:
+
+#### OnExternalDataHandler
+
+Example:
+```typescript
+import { OnExternalDataHandler } from '@metamask/snaps-types';
+import { assert } from '@metamask/utils';
+
+export const onExternalData: OnExternalDataHandler = ({ id, type, data, source }) => {
+  assert(type === 'websocket'); // `data` is inferred as `WebSocketData`.
+  assert(data.type === 'text'); // `message` is inferred as `string`.
+
+  // Now the Snap can do whatever is needed with the message.
+  const json = JSON.parse(data.message);
+};
+```
+
+Snap that wants to use external data sources MUST have `onExternalData` function export.
+
+Exported function SHOULD accept an object parameter that MAY have `id`, `type`, `data` and `source` properties.
+
+This export SHOULD be called every time the WebSocket client or Blockchain event listener receives some data or event.
+
+The parameters represent the following:
+- `id`: Unique ID of an event generated internally on the controller side. This can be used for tracking each event
+  in case of storage needs or debugging. The `id` MUST be unique string.
+- `data`: SHOULD be the raw message that the WebSocket client received. Depending on the `type`, this SHOULD be
+  either a `string` or an `ArrayBuffer`.
+- `type`: The type of the message that was sent. This SHOULD be either `text` or `binary`.
+- `source`: The URL that the message was sent from. Snaps can use this to differentiate between different endpoints.
+  This SHOULD be the exact same URL as specified in manifest.
+
+The RECOMMENDED specification of types of `OnExternalDataHandler` and its parameters:
+
+```typescript
+type WebSocketMessage = {
+  type: 'text';
+  message: string;
+} | {
+  type: 'binary';
+  message: ArrayBuffer;
+};
+
+type WebSocketData = {
+  type: 'websocket';
+  data: WebSocketMessage;
+};
+
+type ExternalData = WebSocketData;
+
+type OnExternalDataHandlerArgs = ExternalData & {
+  source: string;
+};
+
+type OnExternalDataHandler = (args: OnExternalDataHandlerArgs) => Promise<void>;
+```
+
+The specification MAY be extended or changed depending on a type of data or event sources and their implementation
+needs.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE).

--- a/SIPS/sip-20.md
+++ b/SIPS/sip-20.md
@@ -70,18 +70,21 @@ The new field can be specified as follows in a `snap.manifest.json` file:
 ```json
 {
   "initialPermissions": {
-    "endowment:external-data": [
-      {
-        "type": "websocket",
-        "url": "wss://example.com/binary/endpoint",
-        "dataType": "binary"
-      },
-      {
-        "type": "websocket",
-        "url": "wss://example.com/text/endpoint",
-        "dataType": "text"
-      }
-    ]
+    "endowment:external-data": {
+      "maxRequestTime": 50000,
+      "connections": [
+        {
+          "type": "websocket",
+          "url": "wss://example.com/binary/endpoint",
+          "dataType": "binary"
+        },
+        {
+          "type": "websocket",
+          "url": "wss://example.com/text/endpoint",
+          "dataType": "text"
+        }
+      ]
+    }
   }
 }
 ```
@@ -167,7 +170,7 @@ type OnExternalDataHandler = (args: OnExternalDataHandlerArgs) => Promise<void>;
 import { OnExternalDataHandler } from '@metamask/snaps-types';
 import { assert } from '@metamask/utils';
 
-export const onExternalData: OnExternalDataHandler = ({ id, type, data, source }) => {
+export const onExternalData: OnExternalDataHandler = ({ type, data, source }) => {
   assert(type === 'websocket'); // `data` is inferred as `WebSocketData`.
   assert(data.type === 'text'); // `message` is inferred as `string`.
 

--- a/SIPS/sip-20.md
+++ b/SIPS/sip-20.md
@@ -26,7 +26,7 @@ Snaps are currently limited in their ability to receive data from external sourc
 
 The key words "MUST", "MUST NOT", "SHOULD", "RECOMMENDED" and "MAY" written in uppercase in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
-### Snap Manifest
+### Snap manifest
 
 This SIP introduces a new permission named `endowment:external-data`.
 
@@ -80,13 +80,6 @@ The new field can be specified as follows in a `snap.manifest.json` file:
         "type": "websocket",
         "url": "wss://example.com/text/endpoint",
         "dataType": "text"
-      },
-      {
-        "type": "blockchain",
-        "chainId": "eip155:1",
-        "events": [
-          "block"
-        ]
       }
     ]
   }
@@ -129,6 +122,7 @@ type WebSocketTextMessage = {
   type: 'text';
   message: string;
 };
+
 /**
  * A binary message received from a WebSocket.
  *
@@ -139,6 +133,7 @@ type WebSocketBinaryMessage = {
   type: 'binary';
   message: ArrayBuffer;
 };
+
 /**
  * A message received from a WebSocket.
  *
@@ -150,6 +145,7 @@ type WebSocketData = {
   type: 'websocket';
   data: WebSocketTextMessage | WebSocketBinaryMessage;
 };
+
 /**
  * The data received from an external source.
  *
@@ -157,9 +153,11 @@ type WebSocketData = {
  * @property data - The data received from the external data source.
  */
 type ExternalData = WebSocketData;
+
 type OnExternalDataHandlerArgs = ExternalData & {
   source: string;
 };
+
 type OnExternalDataHandler = (args: OnExternalDataHandlerArgs) => Promise<void>;
 ```
 

--- a/SIPS/sip-20.md
+++ b/SIPS/sip-20.md
@@ -59,8 +59,15 @@ type ExternalDataConnection = WebSocketConnection;
  *
  * This is the value of the `endowment:external-data` field in the Snap
  * manifest.
+ *
+ * @property maxRequestTime - The maximum request time for the `onExternalData`
+ * entry point, as described in SIP-21.
+ * @property connections - The external data connections.
  */
-type ExternalData = { connections: ExternalDataConnection[] };
+type ExternalData = {
+    maxRequestTime?: number;
+    connections: ExternalDataConnection[]
+};
 ```
 
 #### Example

--- a/SIPS/sip-20.md
+++ b/SIPS/sip-20.md
@@ -16,7 +16,7 @@ The Snap can then do whatever it wants with the data. This initial version only 
 
 ## Motivation
 
-Snaps are currently limited in their ability to receive data from external sources: Either they have to rely on user actions or cron jobs to fetch data, so they can't react to events in real time. Snaps also cannot use WebSocket connections to receive data from external sources, and are limited to HTTP requests.
+Snaps are currently limited in their ability to receive data from external sources; they have to rely on user actions or cron jobs to fetch data, so they can't react to events in real time. Snaps also cannot use WebSocket connections to receive data from external sources, and are limited to HTTP requests.
 
 ## Specification
 

--- a/SIPS/sip-20.md
+++ b/SIPS/sip-20.md
@@ -60,7 +60,7 @@ type ExternalDataConnection = WebSocketConnection;
  * This is the value of the `endowment:external-data` field in the Snap
  * manifest.
  */
-type ExternalData = ExternalDataConnection[];
+type ExternalData = { connections: ExternalDataConnection[] };
 ```
 
 #### Example


### PR DESCRIPTION
This PR adds `SIP-20` that proposes a new feature that supports one-way communication used for receiving an external data from WebSockets and other data or event sources.
