### PR TITLE
Signature insights type fix

### DIFF
--- a/SIPS/sip-16.md
+++ b/SIPS/sip-16.md
@@ -165,7 +165,7 @@ interface PersonalSignature {
 ```typescript
 interface SignTypedDataSignature {
   from: string;
-  data: Record<string, any>;
+  data: Record<string, any>[];
   signatureMethod: 'eth_signTypedData';
 }
 ```


### PR DESCRIPTION
The `data` param for `eth_signTypedData` should be an array of records, not just a record.