### PR TITLE
Update response object for `AddressResolution`

### DIFF
--- a/SIPS/sip-12.md
+++ b/SIPS/sip-12.md
@@ -128,6 +128,7 @@ The interface for the return value of an `onNameLookup` export is:
 type AddressResolution = {
   protocol: string;
   resolvedAddress: AccountAddress;
+  domainName: string;
 };
 
 type DomainResolution = {
@@ -148,7 +149,8 @@ type OnNameLookupResponse =
 1. The `resolvedDomain` or `resolvedAddress` in a resolution object MUST be the key that the address or domain being queried is indexed by in the protocol that the snap is resolving for. These returned values are un-opinionated at the API layer to allow the client to use them as they see fit.
 2. There MUST NOT be duplicate resolutions for the same protocol in either `resolvedAddresses` or `resolvedDomains`.
 3. `protocol` refers to the name of the protocol providing resolution for said `resolvedAddress`/`resolvedDomain`.
-4. The returned resolution(s) MUST exist on the chain specificed by the `chainId` passed into the handler.
+4. For address resolutions, the `domainName` property pertains to the domain that the address was resolved for. In most instances this will be just the `domain` passed into the lookup handler. However, the requirement of this property allows a snap to make fuzzy matches and indicate the domain name that was fuzzy matched in the response.
+5. The returned resolution(s) MUST exist on the chain specificed by the `chainId` passed into the handler.
 
 ## Copyright
 


### PR DESCRIPTION
This update will essentially allow a snap to make fuzzy matches. Previously, the client had no way to discern if an input (`domain`) was being fuzzy matched or not as it had no information in the response about the actual `domain` that was resolved against.