### PR TITLE
SIP-29: Snap Assets API

### DIFF
--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -1,0 +1,196 @@
+---
+sip: (To be assigned)
+title: Snap Assets API
+status: Draft
+discussions-to (*optional): (Http/Https URL)
+author: Daniel Rocha (@danroc), Guillaume Roux (@GuillaumeRx)
+created: (Date created on in ISO 8601 format. `yyyy-mm-dd`)
+updated (*optional): (Date last updated on in https://en.wikipedia.org/wiki/ISO_8601 format. `yyyy-mm-dd`. This should be only used on SIPs with `Living` status)
+---
+
+## Abstract
+
+This SIP aims to define a new API that can be exposed by Snaps to allow clients
+get asset information in a chain-agnostic way.
+
+## Motivation
+
+To allow clients to be chain-agnostic, the logic of how to get asset
+information should be abstracted away from the client. We also need to define
+the types that represent the asset information required by the clients.
+
+## Specification
+
+> Indented sections like this are considered non-normative.
+
+### Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" written
+in uppercase in this document are to be interpreted as described in [RFC
+2119](https://www.ietf.org/rfc/rfc2119.txt)
+
+### Definitions
+
+In this document, all definitions are written in TypeScript. Also, any time an
+asset need to be identified, it MUST use the [CAIP-19][caip-19] representation.
+
+### Snap Assets API
+
+Two methods are defined in the Snap Assets API:
+
+#### Get Token Description
+
+```typescript
+// Represents a token unit.
+type TokenUnit {
+    // Human-friendly name of the token unit.
+    name: string;
+
+    // Ticker of the token unit.
+    ticker: string;
+
+    // Number of decimals of the token unit.
+    decimals: number;
+}
+
+// Token description.
+type TokenDescription {
+    // Human-friendly name of the token.
+    name: string;
+
+    // Ticker of the token.
+    ticker: string;
+
+    // Whether the token is native to the chain.
+    isNative: boolean;
+
+    // Base64 representation of the token icon.
+    iconBase64: string;
+
+    // List of token units.
+    units: TokenUnit[];
+}
+
+// Returns the description of a non-fungible token. This description can then
+// be used by the client to display relevant information about the token.
+//
+// @example
+// ```typescript
+// const tokenDescription = await getTokenDescription('eip155:1/slip44:60');
+//
+// // Returns:
+// // {
+// //     name: 'Ether',
+// //     ticker: 'ETH',
+// //     isNative: true,
+// //     iconBase64: 'data:image/png;base64,...',
+// //     units: [
+// //         {
+// //             name: 'Ether',
+// //             ticker: 'ETH',
+// //             decimals: 18
+// //         },
+// //         {
+// //             name: 'Gwei',
+// //             ticker: 'Gwei',
+// //             decimals: 9
+// //         },
+// //         {
+// //             name: 'wei',
+// //             ticker: 'wei',
+// //             decimals: 0
+// //         }
+// //     ]
+// ```
+function getTokenDescription(token: Caip19AssetType): TokenDescription;
+```
+
+#### Get Token Conversion Rate
+
+```typescript
+type TokenConversionRate {
+    // The rate of conversion from the source token to the target token. It
+    // means that 1 unit of the `from` token should be converted to this amount
+    // of the `to` token.
+    rate: string;
+
+    // The UNIX timestamp of when the conversion rate was last updated.
+    conversionTime: number;
+
+    // The UNIX timestamp of when the conversion rate will expire.
+    expirationTime: number;
+}
+
+// Returns the conversion rate between two assets (tokens or fiat).
+//
+// @example
+// ```typescript
+// const conversionRate = await getTokenConversionRate(
+//   'eip155:1/slip44:60',
+//   'eip155:1/erc20:0x6b175474e89094c44da98b954eedeac495271d0f'
+// );
+//
+// // Returns:
+// // {
+// //     rate: '3906.38',
+// //     conversionTime: 1733389786,
+// //     expirationTime: 1733389816,
+// // }
+// ```
+function getTokenConversionRate(
+    from: Caip19AssetType,
+    to: Caip19AssetType
+): TokenConversionRate;
+```
+
+### Fiat currency representation
+
+We SHOULD use CAIP-19 to represent fiat currencies as well, it will allow us to
+have a consistent way to represent all assets and make the API more
+predictable.
+
+The propose format is:
+
+```
+asset_type:        chain_id + "/" + asset_namespace + ":" + asset_reference
+chain_id:          namespace + ":" + reference
+namespace:         "fiat"
+reference:         country_code
+asset_namespace:   "currency"
+asset_reference:   currency_code
+```
+
+The country code is a two-letter lowercase code as defined by the ISO 3166-1
+alpha-2, with the exception for the European Union, which is represented by
+"eu".
+
+The currency code is a three-letter uppercase code as defined by the ISO 4217.
+
+Examples:
+
+```
+# Euro
+fiat:eu/currency:eur
+
+# United States Dollar
+fiat:us/currency:usd
+
+# Brazilian Real
+fiat:br/currency:brl
+
+# Japanese Yen
+fiat:jp/currency:jpy
+```
+
+## Backwards compatibility
+
+Any SIPs that break backwards compatibility MUST include a section describing
+those incompatibilities and their severity. The SIP SHOULD describe how the
+author plans on proposes to deal with such these incompatibilities.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE).
+
+[caip-19]: https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-19.md

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -144,7 +144,7 @@ type OnAssetConversionReturn = {
 
 ### Fiat currency representation
 
-We SHOULD use CAIP-19 to represent fiat currencies as well. This approach
+We SHOULD use [CAIP-19][caip-19] to represent fiat currencies as well. This approach
 provides a consistent way to represent all assets, making the API more
 predictable. The proposed format is:
 

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -33,7 +33,7 @@ in uppercase in this document are to be interpreted as described in [RFC
 1. In this document, all definitions are written in TypeScript.
 
 2. Any time an asset needs to be identified, it MUST use the [CAIP-19][caip-19]
-representation.
+   representation.
 
 ### Snap Manifest
 
@@ -46,9 +46,9 @@ This permission is specified as follows in `snap.manifest.json` files:
 {
   "initialPermissions": {
     "endowment:assets": {
-        "scopes": [
-            "bip122:000000000019d6689c085ae165831e93"
-        ]
+      "scopes": [
+        "bip122:000000000019d6689c085ae165831e93"
+      ]
     }
   }
 }
@@ -77,17 +77,17 @@ export const onAssetLookup: OnAssetLookupHandler = async ({
 
 The type for an `onAssetLookup` handler function’s arguments is:
 
-
 ```typescript
 interface OnAssetLookupArgs {
-    assets: Caip19AssetType[];
+  assets: Caip19AssetType[];
 }
 ```
+
 The type for an `onAssetLookup` handler function’s return value is:
 
 ```typescript
 type OnAssetLookupReturn = {
-    assets: Record<Caip19AssetType, AssetMetadata>;
+  assets: Record<Caip19AssetType, AssetMetadata>;
 };
 ```
 
@@ -103,32 +103,34 @@ export const onAssetConversion: OnAssetConversionHandler = async ({
   return { conversionRates };
 };
 ```
+
 The type for an `onAssetConversion` handler function’s arguments is:
 
 ```typescript
 type Conversion = {
-    from: Caip19AssetType;
-    to: Caip19AssetType;
+  from: Caip19AssetType;
+  to: Caip19AssetType;
 };
 
 type OnAssetConversionArgs = {
-    conversions: Conversion[];
-}
+  conversions: Conversion[];
+};
 ```
+
 The type for an `onAssetConversion` handler function’s return value is:
 
 ```typescript
 type AssetConversionRate = {
-    // The rate of conversion from the source asset to the target asset. It
-    // means that 1 unit of the `from` asset should be converted to this amount
-    // of the `to` asset.
-    rate: string;
+  // The rate of conversion from the source asset to the target asset. It
+  // means that 1 unit of the `from` asset should be converted to this amount
+  // of the `to` asset.
+  rate: string;
 
-    // The UNIX timestamp of when the conversion rate was last updated.
-    conversionTime: number;
+  // The UNIX timestamp of when the conversion rate was last updated.
+  conversionTime: number;
 
-    // The UNIX timestamp of when the conversion rate will expire.
-    expirationTime: number;
+  // The UNIX timestamp of when the conversion rate will expire.
+  expirationTime: number;
 };
 
 type FromAsset = Conversion["from"];
@@ -136,7 +138,7 @@ type FromAsset = Conversion["from"];
 type ToAsset = Conversion["to"];
 
 type OnAssetConversionReturn = {
-    conversionRates: Record<From, Record<To, AssetConversionRate>>;
+  conversionRates: Record<From, Record<To, AssetConversionRate>>;
 };
 ```
 
@@ -185,38 +187,37 @@ As of the time of creation of this SIP, they are the only possible assets reques
 ```typescript
 // Represents an asset unit.
 type FungibleAssetUnit = {
-    // Human-friendly name of the asset unit.
-    name: string;
+  // Human-friendly name of the asset unit.
+  name: string;
 
-    // Ticker of the asset unit.
-    ticker: string;
+  // Ticker of the asset unit.
+  ticker: string;
 
-    // Number of decimals of the asset unit.
-    decimals: number;
+  // Number of decimals of the asset unit.
+  decimals: number;
 };
 
 // Fungible asset metadata.
 type FungibleAssetMetadata = {
-    // Human-friendly name of the asset.
-    name: string;
+  // Human-friendly name of the asset.
+  name: string;
 
-    // Ticker of the asset.
-    ticker: string;
+  // Ticker of the asset.
+  ticker: string;
 
-    // Whether the asset is native to the chain.
-    native: boolean;
+  // Whether the asset is native to the chain.
+  native: boolean;
 
-    // Represents a fungible asset
-    fungible: true;
+  // Represents a fungible asset
+  fungible: true;
 
-    // Base64 representation of the asset icon.
-    iconBase64: string;
+  // Base64 representation of the asset icon.
+  iconBase64: string;
 
-    // List of asset units.
-    units: FungibleAssetUnit[];
+  // List of asset units.
+  units: FungibleAssetUnit[];
 };
 ```
-
 
 ## Backwards compatibility
 

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -217,6 +217,9 @@ type FungibleAssetMetadata = {
   // List of asset units.
   units: FungibleAssetUnit[];
 };
+
+// Represents the metadata of an asset.
+type AssetMetadata = FungibleAssetMetadata
 ```
 
 ## Backwards compatibility

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -190,8 +190,8 @@ type FungibleAssetUnit = {
   // Human-friendly name of the asset unit.
   name: string;
 
-  // Ticker of the asset unit.
-  ticker: string;
+  // Ticker symbol of the asset unit.
+  symbol: string;
 
   // Number of decimals of the asset unit.
   decimals: number;
@@ -202,8 +202,8 @@ type FungibleAssetMetadata = {
   // Human-friendly name of the asset.
   name: string;
 
-  // Ticker of the asset.
-  ticker: string;
+  // Ticker symbol of the asset's main unit.
+  symbol: string;
 
   // Whether the asset is native to the chain.
   native: boolean;

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -11,13 +11,13 @@ updated (*optional): (Date last updated on in https://en.wikipedia.org/wiki/ISO_
 ## Abstract
 
 This SIP aims to define a new API that can be exposed by Snaps to allow clients
-get asset information in a chain-agnostic way.
+to retrieve asset information in a chain-agnostic way.
 
 ## Motivation
 
-To allow clients to be chain-agnostic, the logic of how to get asset
-information should be abstracted away from the client. We also need to define
-the types that represent the asset information required by the clients.
+To enable clients to be chain-agnostic, the logic for obtaining asset
+information should be abstracted away from the client. Additionally, this SIP
+defines the types that represent the asset information required by clients.
 
 ## Specification
 
@@ -32,8 +32,10 @@ in uppercase in this document are to be interpreted as described in [RFC
 
 ### Definitions
 
-In this document, all definitions are written in TypeScript. Also, any time an
-asset need to be identified, it MUST use the [CAIP-19][caip-19] representation.
+1. In this document, all definitions are written in TypeScript.
+
+2. Any time an asset needs to be identified, it MUST use the [CAIP-19][caip-19]
+representation.
 
 ### Snap Assets API
 
@@ -43,7 +45,7 @@ Two methods are defined in the Snap Assets API:
 
 ```typescript
 // Represents a token unit.
-type TokenUnit {
+type TokenUnit = {
     // Human-friendly name of the token unit.
     name: string;
 
@@ -52,10 +54,10 @@ type TokenUnit {
 
     // Number of decimals of the token unit.
     decimals: number;
-}
+};
 
 // Token description.
-type TokenDescription {
+type TokenDescription = {
     // Human-friendly name of the token.
     name: string;
 
@@ -70,7 +72,7 @@ type TokenDescription {
 
     // List of token units.
     units: TokenUnit[];
-}
+};
 
 // Returns the description of a non-fungible token. This description can then
 // be used by the client to display relevant information about the token.
@@ -102,6 +104,7 @@ type TokenDescription {
 // //             decimals: 0
 // //         }
 // //     ]
+// // }
 // ```
 function getTokenDescription(token: Caip19AssetType): TokenDescription;
 ```
@@ -109,7 +112,7 @@ function getTokenDescription(token: Caip19AssetType): TokenDescription;
 #### Get Token Conversion Rate
 
 ```typescript
-type TokenConversionRate {
+type TokenConversionRate = {
     // The rate of conversion from the source token to the target token. It
     // means that 1 unit of the `from` token should be converted to this amount
     // of the `to` token.
@@ -120,7 +123,7 @@ type TokenConversionRate {
 
     // The UNIX timestamp of when the conversion rate will expire.
     expirationTime: number;
-}
+};
 
 // Returns the conversion rate between two assets (tokens or fiat).
 //
@@ -146,11 +149,9 @@ function getTokenConversionRate(
 
 ### Fiat currency representation
 
-We SHOULD use CAIP-19 to represent fiat currencies as well, it will allow us to
-have a consistent way to represent all assets and make the API more
-predictable.
-
-The propose format is:
+We SHOULD use CAIP-19 to represent fiat currencies as well. This approach
+provides a consistent way to represent all assets, making the API more
+predictable. The proposed format is:
 
 ```
 asset_type:        chain_id + "/" + asset_namespace + ":" + asset_reference
@@ -161,11 +162,10 @@ asset_namespace:   "currency"
 asset_reference:   currency_code
 ```
 
-The country code is a two-letter lowercase code as defined by the ISO 3166-1
-alpha-2, with the exception for the European Union, which is represented by
-"eu".
+The country code is a two-letter lowercase code as defined by ISO 3166-1
+alpha-2, with the exception of the European Union, represented by "eu".
 
-The currency code is a three-letter uppercase code as defined by the ISO 4217.
+The currency code is a three-letter uppercase code as defined by ISO 4217.
 
 Examples:
 

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -86,7 +86,7 @@ interface OnAssetLookupArgs {
 The type for an `onAssetLookup` handler function’s return value is:
 
 ```typescript
-type OnAssetLookupReturn = {
+type OnAssetLookupResponse = {
   assets: Record<Caip19AssetType, AssetMetadata>;
 };
 ```

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -54,7 +54,7 @@ This permission is specified as follows in `snap.manifest.json` files:
 }
 ```
 
-`scopes` - A non-empty array of CAIP-2 chain IDs that the Snap supports. This field is useful for a client in order to avoid unnecessary overhead.
+`scopes` - A non-empty array of CAIP-2 chain IDs that the Snap supports. This field is useful for a client in order to avoid unnecessary overhead. Any asset returned by the Snap must be from one of the supported chains otherwise it will get filtered out.
 
 ### Snap Implementation
 
@@ -62,7 +62,7 @@ Two methods are defined in the Snap Assets API:
 
 Any Snap that wishes to provide asset information MUST implement the following API:
 
-#### Get Asset Metadata
+#### Get Assets Metadata
 
 `Caip19AssetType` -  A string that represents an asset using the [CAIP-19][caip-19] standard.
 
@@ -93,7 +93,7 @@ type OnAssetsLookupResponse = {
 };
 ```
 
-#### Get Asset Conversion Rate
+#### Get Assets Conversion Rate
 
 ```typescript
 import { OnAssetsConversionHandler } from "@metamask/snaps-sdk";
@@ -132,7 +132,7 @@ type AssetConversionRate = {
   conversionTime: number;
 
   // The UNIX timestamp of when the conversion rate will expire.
-  expirationTime: number;
+  expirationTime?: number;
 };
 
 type FromAsset = Conversion["from"];
@@ -170,14 +170,11 @@ type FungibleAssetMetadata = {
   // Ticker symbol of the asset's main unit.
   symbol: string;
 
-  // Whether the asset is native to the chain.
-  native: boolean;
-
   // Represents a fungible asset
   fungible: true;
 
-  // Base64 representation of the asset icon.
-  iconBase64: string;
+  // data URI or URL representation of the asset icon.
+  iconUrl: string;
 
   // List of asset units.
   units: FungibleAssetUnit[];

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -78,7 +78,7 @@ export const onAssetLookup: OnAssetLookupHandler = async ({
 The type for an `onAssetLookup` handler function’s arguments is:
 
 ```typescript
-interface OnAssetLookupArgs {
+interface OnAssetLookupArguments {
   assets: Caip19AssetType[];
 }
 ```

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -1,11 +1,9 @@
 ---
-sip: (To be assigned)
+sip: 29
 title: Snap Assets API
 status: Draft
-discussions-to (*optional): (Http/Https URL)
 author: Daniel Rocha (@danroc), Guillaume Roux (@GuillaumeRx)
-created: (Date created on in ISO 8601 format. `yyyy-mm-dd`)
-updated (*optional): (Date last updated on in https://en.wikipedia.org/wiki/ISO_8601 format. `yyyy-mm-dd`. This should be only used on SIPs with `Living` status)
+created: 2024-12-05
 ---
 
 ## Abstract

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -64,10 +64,12 @@ Any Snap that wishes to provide asset information MUST implement the following A
 
 #### Get Asset Metadata
 
-```typescript
-import { OnAssetLookupHandler } from "@metamask/snaps-sdk";
+`Caip19AssetType` -  A string that represents an asset using the [CAIP-19][caip-19] standard.
 
-export const onAssetLookup: OnAssetLookupHandler = async ({
+```typescript
+import { OnAssetsLookupHandler } from "@metamask/snaps-sdk";
+
+export const onAssetsLookup: OnAssetsLookupHandler = async ({
   assets
 }) => {
   const assetsMetadata = /* Get metadata for given `assets` */;
@@ -75,18 +77,18 @@ export const onAssetLookup: OnAssetLookupHandler = async ({
 };
 ```
 
-The type for an `onAssetLookup` handler function’s arguments is:
+The type for an `onAssetsLookup` handler function’s arguments is:
 
 ```typescript
-interface OnAssetLookupArguments {
+interface OnAssetsLookupArguments {
   assets: Caip19AssetType[];
 }
 ```
 
-The type for an `onAssetLookup` handler function’s return value is:
+The type for an `onAssetsLookup` handler function’s return value is:
 
 ```typescript
-type OnAssetLookupResponse = {
+type OnAssetsLookupResponse = {
   assets: Record<Caip19AssetType, AssetMetadata>;
 };
 ```
@@ -94,9 +96,9 @@ type OnAssetLookupResponse = {
 #### Get Asset Conversion Rate
 
 ```typescript
-import { OnAssetConversionHandler } from "@metamask/snaps-sdk";
+import { OnAssetsConversionHandler } from "@metamask/snaps-sdk";
 
-export const onAssetConversion: OnAssetConversionHandler = async ({
+export const onAssetsConversion: OnAssetsConversionHandler = async ({
   conversions
 }) => {
   const conversionRates = /* Get conversion rate for given `conversions` */;
@@ -104,7 +106,7 @@ export const onAssetConversion: OnAssetConversionHandler = async ({
 };
 ```
 
-The type for an `onAssetConversion` handler function’s arguments is:
+The type for an `onAssetsConversion` handler function’s arguments is:
 
 ```typescript
 type Conversion = {
@@ -112,17 +114,17 @@ type Conversion = {
   to: Caip19AssetType;
 };
 
-type OnAssetConversionArguments = {
+type OnAssetsConversionArguments = {
   conversions: Conversion[];
 };
 ```
 
-The type for an `onAssetConversion` handler function’s return value is:
+The type for an `onAssetsConversion` handler function’s return value is:
 
 ```typescript
 type AssetConversionRate = {
-  // The rate of conversion from the source asset to the target asset. It
-  // means that 1 unit of the `from` asset should be converted to this amount
+  // The rate of conversion from the source asset to the target asset represented as a decimal number in a string.
+  // It means that 1 unit of the `from` asset should be converted to this amount
   // of the `to` asset.
   rate: string;
 
@@ -137,46 +139,9 @@ type FromAsset = Conversion["from"];
 
 type ToAsset = Conversion["to"];
 
-type OnAssetConversionResponse = {
+type OnAssetsConversionResponse = {
   conversionRates: Record<From, Record<To, AssetConversionRate>>;
 };
-```
-
-### Fiat currency representation
-
-We SHOULD use [CAIP-19][caip-19] to represent fiat currencies as well. This approach
-provides a consistent way to represent all assets, making the API more
-predictable. The proposed format is:
-
-```
-asset_type:        chain_id + "/" + asset_namespace + ":" + asset_reference
-chain_id:          namespace + ":" + reference
-namespace:         "fiat"
-reference:         country_code
-asset_namespace:   "currency"
-asset_reference:   currency_code
-```
-
-The country code is a two-letter lowercase code, as defined by ISO 3166-1
-alpha-2, representing the emitter country, with the exception of the European
-Union, which is represented by "eu".
-
-The currency code is a three-letter uppercase code as defined by ISO 4217.
-
-Examples:
-
-```
-# Euro
-fiat:eu/currency:eur
-
-# United States Dollar
-fiat:us/currency:usd
-
-# Brazilian Real
-fiat:br/currency:brl
-
-# Japanese Yen
-fiat:jp/currency:jpy
 ```
 
 ## Appendix I: Fungible Asset Metadata

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -137,7 +137,7 @@ type FromAsset = Conversion["from"];
 
 type ToAsset = Conversion["to"];
 
-type OnAssetConversionReturn = {
+type OnAssetConversionResponse = {
   conversionRates: Record<From, Record<To, AssetConversionRate>>;
 };
 ```

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -112,7 +112,7 @@ type Conversion = {
   to: Caip19AssetType;
 };
 
-type OnAssetConversionArgs = {
+type OnAssetConversionArguments = {
   conversions: Conversion[];
 };
 ```

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -54,7 +54,7 @@ This permission is specified as follows in `snap.manifest.json` files:
 }
 ```
 
-`scopes` - A non-empty array of CAIP-2 chain IDs that the Snap supports. This field is useful for a client in order to avoid unnecessary overhead. Any asset returned by the Snap must be from one of the supported chains otherwise it will get filtered out.
+`scopes` - A non-empty array of CAIP-2 chain IDs that the Snap supports. This field is useful for a client in order to avoid unnecessary overhead. Any asset returned by the Snap MUST be filtered out if it isn't part of the supported scopes.
 
 ### Snap Implementation
 
@@ -64,7 +64,7 @@ Any Snap that wishes to provide asset information MUST implement the following A
 
 #### Get Assets Metadata
 
-`Caip19AssetType` -  A string that represents an asset using the [CAIP-19][caip-19] standard.
+`Caip19AssetType` - A string that represents an asset using the [CAIP-19][caip-19] standard.
 
 ```typescript
 import { OnAssetsLookupHandler } from "@metamask/snaps-sdk";
@@ -173,7 +173,7 @@ type FungibleAssetMetadata = {
   // Represents a fungible asset
   fungible: true;
 
-  // data URI or URL representation of the asset icon.
+  // Base64 data URI or URL representation of the asset icon.
   iconUrl: string;
 
   // List of asset units.

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -54,7 +54,7 @@ This permission is specified as follows in `snap.manifest.json` files:
 }
 ```
 
-`scopes` - A non-empty array of CAIP-2 chain IDs that the snap supports. This field is useful for a client in order to avoid unnecessary overhead.
+`scopes` - A non-empty array of CAIP-2 chain IDs that the Snap supports. This field is useful for a client in order to avoid unnecessary overhead.
 
 ### Snap Implementation
 

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -70,7 +70,7 @@ import { OnAssetLookupHandler } from "@metamask/snaps-sdk";
 export const onAssetLookup: OnAssetLookupHandler = async ({
   assets
 }) => {
-  const assetsMetadata = /* Get metadata */;
+  const assetsMetadata = /* Get metadata for given `assets` */;
   return { assets: assetsMetadata };
 };
 ```

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -222,12 +222,6 @@ type FungibleAssetMetadata = {
 type AssetMetadata = FungibleAssetMetadata
 ```
 
-## Backwards compatibility
-
-Any SIPs that break backwards compatibility MUST include a section describing
-those incompatibilities and their severity. The SIP SHOULD describe how the
-author plans on proposes to deal with such these incompatibilities.
-
 ## Copyright
 
 Copyright and related rights waived via [CC0](../LICENSE).

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -160,8 +160,9 @@ asset_namespace:   "currency"
 asset_reference:   currency_code
 ```
 
-The country code is a two-letter lowercase code as defined by ISO 3166-1
-alpha-2, with the exception of the European Union, represented by "eu".
+The country code is a two-letter lowercase code, as defined by ISO 3166-1
+alpha-2, representing the emitter country, with the exception of the European
+Union, which is represented by "eu".
 
 The currency code is a three-letter uppercase code as defined by ISO 4217.
 

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -60,7 +60,7 @@ This permission is specified as follows in `snap.manifest.json` files:
 
 Two methods are defined in the Snap Assets API:
 
-Any Snap that wishes to provide asset information **MUST** implement the following API:
+Any Snap that wishes to provide asset information MUST implement the following API:
 
 #### Get Asset Metadata
 

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -99,7 +99,7 @@ import { OnAssetConversionHandler } from "@metamask/snaps-sdk";
 export const onAssetConversion: OnAssetConversionHandler = async ({
   conversions
 }) => {
-  const conversionRates = /* Get conversion rate */;
+  const conversionRates = /* Get conversion rate for given `conversions` */;
   return { conversionRates };
 };
 ```


### PR DESCRIPTION
This SIP aims to define a new API that can be exposed by Snaps to allow clients to retrieve asset information in a chain-agnostic way.