### PR TITLE
SIP-29 Improvements

### DIFF
--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -68,7 +68,7 @@ Any Snap that wishes to provide asset information **MUST** implement the followi
 import { OnAssetDescriptionHandler } from "@metamask/snaps-sdk";
 
 export const onAssetDescription: OnAssetDescriptionHandler = async ({
-  asset
+  assets
 }) => {
   const description = /* Get description */;
   return { description };
@@ -79,12 +79,36 @@ The type for an `onAssetDescription` handler function’s arguments is:
 
 ```typescript
 interface OnAssetDescriptionArgs {
-    asset: Caip19AssetType;
+    assets: Caip19AssetType[];
 }
 ```
 The type for an `onAssetDescription` handler function’s return value is:
 
 ```typescript
+// {
+//     name: 'Ether',
+//     ticker: 'ETH',
+//     isNative: true,
+//     iconBase64: 'data:image/png;base64,...',
+//     units: [
+//         {
+//             name: 'Ether',
+//             ticker: 'ETH',
+//             decimals: 18
+//         },
+//         {
+//             name: 'Gwei',
+//             ticker: 'Gwei',
+//             decimals: 9
+//         },
+//         {
+//             name: 'wei',
+//             ticker: 'wei',
+//             decimals: 0
+//         }
+//    ]
+// }
+
 // Represents a asset unit.
 type AssetUnit = {
     // Human-friendly name of the asset unit.
@@ -118,32 +142,9 @@ type AssetDescription = {
     units: AssetUnit[];
 };
 
-// {
-//     name: 'Ether',
-//     ticker: 'ETH',
-//     isNative: true,
-//     iconBase64: 'data:image/png;base64,...',
-//     units: [
-//         {
-//             name: 'Ether',
-//             ticker: 'ETH',
-//             decimals: 18
-//         },
-//         {
-//             name: 'Gwei',
-//             ticker: 'Gwei',
-//             decimals: 9
-//         },
-//         {
-//             name: 'wei',
-//             ticker: 'wei',
-//             decimals: 0
-//         }
-//    ]
-// }
 
 type OnAssetDescriptionReturn = {
-    description: AssetDescription;
+    description: Record<Caip19AssetType, AssetDescription>;
 };
 ```
 
@@ -164,7 +165,7 @@ The type for an `onAssetDescription` handler function’s arguments is:
 
 ```typescript
 interface OnAssetConversionArgs {
-    from: Caip19AssetType;
+    from: Caip19AssetType[];
     to: Caip19AssetType;
 }
 ```
@@ -192,7 +193,7 @@ type AssetConversionRate = {
 // }
 
 type OnAssetConversionReturn = {
-    conversionRate: AssetConversionRate;
+    conversionRate: Record<Caip19AssetType, AssetConversionRate>;
 };
 ```
 

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -38,7 +38,7 @@ representation.
 ### Snap Manifest
 
 This SIP introduces a new permission named `endowment:assets`.
-This permission grants a snap the ability to provide asset information to the client.
+This permission grants a Snap the ability to provide asset information to the client.
 
 This permission is specified as follows in `snap.manifest.json` files:
 
@@ -54,7 +54,7 @@ This permission is specified as follows in `snap.manifest.json` files:
 
 Two methods are defined in the Snap Assets API:
 
-Any snap that wishes to provide asset information **MUST** implement the following API:
+Any Snap that wishes to provide asset information **MUST** implement the following API:
 
 #### Get Token Description
 

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -56,7 +56,7 @@ Two methods are defined in the Snap Assets API:
 
 Any Snap that wishes to provide asset information **MUST** implement the following API:
 
-#### Get Token Description
+#### Get Asset Description
 
 ```typescript
 import { OnAssetDescriptionHandler } from "@metamask/snaps-sdk";
@@ -79,34 +79,37 @@ interface OnAssetDescriptionArgs {
 The type for an `onAssetDescription` handler function’s return value is:
 
 ```typescript
-// Represents a token unit.
+// Represents a asset unit.
 type AssetUnit = {
-    // Human-friendly name of the token unit.
+    // Human-friendly name of the asset unit.
     name: string;
 
-    // Ticker of the token unit.
+    // Ticker of the asset unit.
     ticker: string;
 
-    // Number of decimals of the token unit.
+    // Number of decimals of the asset unit.
     decimals: number;
 };
 
-// Token description.
-type TokenDescription = {
-    // Human-friendly name of the token.
+// Asset description.
+type AssetDescription = {
+    // The CAIP-19 ID of the asset.
+    id: Caip19AssetType;
+
+    // Human-friendly name of the asset.
     name: string;
 
-    // Ticker of the token.
+    // Ticker of the asset.
     ticker: string;
 
-    // Whether the token is native to the chain.
+    // Whether the asset is native to the chain.
     isNative: boolean;
 
-    // Base64 representation of the token icon.
+    // Base64 representation of the asset icon.
     iconBase64: string;
 
-    // List of token units.
-    units: TokenUnit[];
+    // List of asset units.
+    units: AssetUnit[];
 };
 
 // {
@@ -134,11 +137,11 @@ type TokenDescription = {
 // }
 
 type OnAssetDescriptionReturn = {
-    description: TokenDescription;
+    description: AssetDescription;
 };
 ```
 
-#### Get Token Conversion Rate
+#### Get Asset Conversion Rate
 
 ```typescript
 import { OnAssetConversionHandler } from "@metamask/snaps-sdk";
@@ -163,9 +166,9 @@ The type for an `onAssetDescription` handler function’s return value is:
 
 ```typescript
 type AssetConversionRate = {
-    // The rate of conversion from the source token to the target token. It
-    // means that 1 unit of the `from` token should be converted to this amount
-    // of the `to` token.
+    // The rate of conversion from the source asset to the target asset. It
+    // means that 1 unit of the `from` asset should be converted to this amount
+    // of the `to` asset.
     rate: string;
 
     // The UNIX timestamp of when the conversion rate was last updated.
@@ -183,7 +186,7 @@ type AssetConversionRate = {
 // }
 
 type OnAssetConversionReturn = {
-    conversionRate: TokenConversionRate;
+    conversionRate: AssetConversionRate;
 };
 ```
 

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -77,6 +77,7 @@ export const onAssetLookup: OnAssetLookupHandler = async ({
 
 The type for an `onAssetLookup` handler function’s arguments is:
 
+
 ```typescript
 interface OnAssetLookupArgs {
     assets: Caip19AssetType[];
@@ -96,19 +97,22 @@ type OnAssetLookupReturn = {
 import { OnAssetConversionHandler } from "@metamask/snaps-sdk";
 
 export const onAssetConversion: OnAssetConversionHandler = async ({
-  from,
-  to
+  conversions
 }) => {
-  const conversionRate = /* Get conversion rate */;
-  return { conversionRate };
+  const conversionRates = /* Get conversion rate */;
+  return { conversionRates };
 };
 ```
 The type for an `onAssetConversion` handler function’s arguments is:
 
 ```typescript
-interface OnAssetConversionArgs {
-    from: Caip19AssetType[];
+type Conversion = {
+    from: Caip19AssetType;
     to: Caip19AssetType;
+};
+
+type OnAssetConversionArgs = {
+    conversions: Conversion[];
 }
 ```
 The type for an `onAssetConversion` handler function’s return value is:
@@ -127,15 +131,12 @@ type AssetConversionRate = {
     expirationTime: number;
 };
 
+type FromAsset = Conversion["from"];
 
-// {
-//     rate: '3906.38',
-//     conversionTime: 1733389786,
-//     expirationTime: 1733389816,
-// }
+type ToAsset = Conversion["to"];
 
 type OnAssetConversionReturn = {
-    conversionRate: Record<Caip19AssetType, AssetConversionRate>;
+    conversionRate: Record<From, Record<To, AssetConversionRate>>;
 };
 ```
 

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -35,15 +35,52 @@ in uppercase in this document are to be interpreted as described in [RFC
 2. Any time an asset needs to be identified, it MUST use the [CAIP-19][caip-19]
 representation.
 
-### Snap Assets API
+### Snap Manifest
+
+This SIP introduces a new permission named `endowment:assets`.
+This permission grants a snap the ability to provide asset information to the client.
+
+This permission is specified as follows in `snap.manifest.json` files:
+
+```json
+{
+  "initialPermissions": {
+    "endowment:assets": {}
+  }
+}
+```
+
+### Snap Implementation
 
 Two methods are defined in the Snap Assets API:
+
+Any snap that wishes to provide asset information **MUST** implement the following API:
 
 #### Get Token Description
 
 ```typescript
+import { OnAssetDescriptionHandler } from "@metamask/snap-types";
+
+export const onAssetDescription: OnAssetDescriptionHandler = async ({
+  asset
+}) => {
+  const description = /* Get description */;
+  return { description };
+};
+```
+
+The type for an `onAssetDescription` handler function’s arguments is:
+
+```typescript
+interface OnAssetDescriptionArgs {
+    asset: Caip19AssetType;
+}
+```
+The type for an `onAssetDescription` handler function’s return value is:
+
+```typescript
 // Represents a token unit.
-type TokenUnit = {
+type AssetUnit = {
     // Human-friendly name of the token unit.
     name: string;
 
@@ -72,45 +109,60 @@ type TokenDescription = {
     units: TokenUnit[];
 };
 
-// Returns the description of a non-fungible token. This description can then
-// be used by the client to display relevant information about the token.
-//
-// @example
-// ```typescript
-// const tokenDescription = await getTokenDescription('eip155:1/slip44:60');
-//
-// // Returns:
-// // {
-// //     name: 'Ether',
-// //     ticker: 'ETH',
-// //     isNative: true,
-// //     iconBase64: 'data:image/png;base64,...',
-// //     units: [
-// //         {
-// //             name: 'Ether',
-// //             ticker: 'ETH',
-// //             decimals: 18
-// //         },
-// //         {
-// //             name: 'Gwei',
-// //             ticker: 'Gwei',
-// //             decimals: 9
-// //         },
-// //         {
-// //             name: 'wei',
-// //             ticker: 'wei',
-// //             decimals: 0
-// //         }
-// //     ]
-// // }
-// ```
-function getTokenDescription(token: Caip19AssetType): TokenDescription;
+// {
+//     name: 'Ether',
+//     ticker: 'ETH',
+//     isNative: true,
+//     iconBase64: 'data:image/png;base64,...',
+//     units: [
+//         {
+//             name: 'Ether',
+//             ticker: 'ETH',
+//             decimals: 18
+//         },
+//         {
+//             name: 'Gwei',
+//             ticker: 'Gwei',
+//             decimals: 9
+//         },
+//         {
+//             name: 'wei',
+//             ticker: 'wei',
+//             decimals: 0
+//         }
+//    ]
+// }
+
+type OnAssetDescriptionReturn = {
+    description: TokenDescription;
+};
 ```
 
 #### Get Token Conversion Rate
 
 ```typescript
-type TokenConversionRate = {
+import { OnAssetConversionHandler } from "@metamask/snap-types";
+
+export const onAssetConversion: OnAssetConversionHandler = async ({
+  from,
+  to
+}) => {
+  const conversionRate = /* Get conversion rate */;
+  return { conversionRate };
+};
+```
+The type for an `onAssetDescription` handler function’s arguments is:
+
+```typescript
+interface OnAssetConversionArgs {
+    from: Caip19AssetType;
+    to: Caip19AssetType;
+}
+```
+The type for an `onAssetDescription` handler function’s return value is:
+
+```typescript
+type AssetConversionRate = {
     // The rate of conversion from the source token to the target token. It
     // means that 1 unit of the `from` token should be converted to this amount
     // of the `to` token.
@@ -123,26 +175,16 @@ type TokenConversionRate = {
     expirationTime: number;
 };
 
-// Returns the conversion rate between two assets (tokens or fiat).
-//
-// @example
-// ```typescript
-// const conversionRate = await getTokenConversionRate(
-//   'eip155:1/slip44:60',
-//   'eip155:1/erc20:0x6b175474e89094c44da98b954eedeac495271d0f'
-// );
-//
-// // Returns:
-// // {
-// //     rate: '3906.38',
-// //     conversionTime: 1733389786,
-// //     expirationTime: 1733389816,
-// // }
-// ```
-function getTokenConversionRate(
-    from: Caip19AssetType,
-    to: Caip19AssetType
-): TokenConversionRate;
+
+// {
+//     rate: '3906.38',
+//     conversionTime: 1733389786,
+//     expirationTime: 1733389816,
+// }
+
+type OnAssetConversionReturn = {
+    conversionRate: TokenConversionRate;
+};
 ```
 
 ### Fiat currency representation

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -184,7 +184,7 @@ As of the time of creation of this SIP, they are the only possible assets reques
 
 ```typescript
 // Represents an asset unit.
-type AssetUnit = {
+type FungibleAssetUnit = {
     // Human-friendly name of the asset unit.
     name: string;
 
@@ -213,7 +213,7 @@ type FungibleAssetMetadata = {
     iconBase64: string;
 
     // List of asset units.
-    units: AssetUnit[];
+    units: FungibleAssetUnit[];
 };
 ```
 

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -136,7 +136,7 @@ type FromAsset = Conversion["from"];
 type ToAsset = Conversion["to"];
 
 type OnAssetConversionReturn = {
-    conversionRate: Record<From, Record<To, AssetConversionRate>>;
+    conversionRates: Record<From, Record<To, AssetConversionRate>>;
 };
 ```
 

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -46,7 +46,7 @@ This permission is specified as follows in `snap.manifest.json` files:
 {
   "initialPermissions": {
     "endowment:assets": {
-        chains: [
+        "chains": [
             "bip122:000000000019d6689c085ae165831e93"
         ]
     }

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -103,7 +103,7 @@ export const onAssetConversion: OnAssetConversionHandler = async ({
   return { conversionRate };
 };
 ```
-The type for an `onAssetDescription` handler function’s arguments is:
+The type for an `onAssetConversion` handler function’s arguments is:
 
 ```typescript
 interface OnAssetConversionArgs {
@@ -111,7 +111,7 @@ interface OnAssetConversionArgs {
     to: Caip19AssetType;
 }
 ```
-The type for an `onAssetDescription` handler function’s return value is:
+The type for an `onAssetConversion` handler function’s return value is:
 
 ```typescript
 type AssetConversionRate = {

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -59,7 +59,7 @@ Any snap that wishes to provide asset information **MUST** implement the followi
 #### Get Token Description
 
 ```typescript
-import { OnAssetDescriptionHandler } from "@metamask/snap-types";
+import { OnAssetDescriptionHandler } from "@metamask/snaps-sdk";
 
 export const onAssetDescription: OnAssetDescriptionHandler = async ({
   asset
@@ -141,7 +141,7 @@ type OnAssetDescriptionReturn = {
 #### Get Token Conversion Rate
 
 ```typescript
-import { OnAssetConversionHandler } from "@metamask/snap-types";
+import { OnAssetConversionHandler } from "@metamask/snaps-sdk";
 
 export const onAssetConversion: OnAssetConversionHandler = async ({
   from,

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -46,7 +46,7 @@ This permission is specified as follows in `snap.manifest.json` files:
 {
   "initialPermissions": {
     "endowment:assets": {
-        "chains": [
+        "scopes": [
             "bip122:000000000019d6689c085ae165831e93"
         ]
     }
@@ -54,7 +54,7 @@ This permission is specified as follows in `snap.manifest.json` files:
 }
 ```
 
-`chains` - A non-empty array of CAIP-2 chain IDs that the snap supports. This field is useful for a client in order to avoid unnecessary overhead.
+`scopes` - A non-empty array of CAIP-2 chain IDs that the snap supports. This field is useful for a client in order to avoid unnecessary overhead.
 
 ### Snap Implementation
 
@@ -62,92 +62,31 @@ Two methods are defined in the Snap Assets API:
 
 Any Snap that wishes to provide asset information **MUST** implement the following API:
 
-#### Get Asset Description
+#### Get Asset Metadata
 
 ```typescript
-import { OnAssetDescriptionHandler } from "@metamask/snaps-sdk";
+import { OnAssetLookupHandler } from "@metamask/snaps-sdk";
 
-export const onAssetDescription: OnAssetDescriptionHandler = async ({
+export const onAssetLookup: OnAssetLookupHandler = async ({
   assets
 }) => {
-  const description = /* Get description */;
-  return { description };
+  const assetsMetadata = /* Get metadata */;
+  return { assets: assetsMetadata };
 };
 ```
 
-The type for an `onAssetDescription` handler function’s arguments is:
+The type for an `onAssetLookup` handler function’s arguments is:
 
 ```typescript
-interface OnAssetDescriptionArgs {
+interface OnAssetLookupArgs {
     assets: Caip19AssetType[];
 }
 ```
-The type for an `onAssetDescription` handler function’s return value is:
+The type for an `onAssetLookup` handler function’s return value is:
 
 ```typescript
-// {
-//     name: 'Ether',
-//     ticker: 'ETH',
-//     isNative: true,
-//     iconBase64: 'data:image/png;base64,...',
-//     units: [
-//         {
-//             name: 'Ether',
-//             ticker: 'ETH',
-//             decimals: 18
-//         },
-//         {
-//             name: 'Gwei',
-//             ticker: 'Gwei',
-//             decimals: 9
-//         },
-//         {
-//             name: 'wei',
-//             ticker: 'wei',
-//             decimals: 0
-//         }
-//    ]
-// }
-
-// Represents a asset unit.
-type AssetUnit = {
-    // Human-friendly name of the asset unit.
-    name: string;
-
-    // Ticker of the asset unit.
-    ticker: string;
-
-    // Number of decimals of the asset unit.
-    decimals: number;
-};
-
-// Asset description.
-type AssetDescription = {
-    // The CAIP-19 ID of the asset.
-    id: Caip19AssetType;
-
-    // Human-friendly name of the asset.
-    name: string;
-
-    // Ticker of the asset.
-    ticker: string;
-
-    // Whether the asset is native to the chain.
-    isNative: boolean;
-
-    // Whether the asset if fungible.
-    isFungible: boolean;
-
-    // Base64 representation of the asset icon.
-    iconBase64: string;
-
-    // List of asset units.
-    units: AssetUnit[];
-};
-
-
-type OnAssetDescriptionReturn = {
-    description: Record<Caip19AssetType, AssetDescription>;
+type OnAssetLookupReturn = {
+    assets: Record<Caip19AssetType, AssetMetadata>;
 };
 ```
 
@@ -236,6 +175,47 @@ fiat:br/currency:brl
 # Japanese Yen
 fiat:jp/currency:jpy
 ```
+
+## Appendix I: Fungible Asset Metadata
+
+The following asset metadata fields for a fungible asset are defined.
+As of the time of creation of this SIP, they are the only possible assets requested by clients.
+
+```typescript
+// Represents an asset unit.
+type AssetUnit = {
+    // Human-friendly name of the asset unit.
+    name: string;
+
+    // Ticker of the asset unit.
+    ticker: string;
+
+    // Number of decimals of the asset unit.
+    decimals: number;
+};
+
+// Fungible asset metadata.
+type FungibleAssetMetadata = {
+    // Human-friendly name of the asset.
+    name: string;
+
+    // Ticker of the asset.
+    ticker: string;
+
+    // Whether the asset is native to the chain.
+    native: boolean;
+
+    // Represents a fungible asset
+    fungible: true;
+
+    // Base64 representation of the asset icon.
+    iconBase64: string;
+
+    // List of asset units.
+    units: AssetUnit[];
+};
+```
+
 
 ## Backwards compatibility
 

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -45,10 +45,16 @@ This permission is specified as follows in `snap.manifest.json` files:
 ```json
 {
   "initialPermissions": {
-    "endowment:assets": {}
+    "endowment:assets": {
+        chains: [
+            "bip122:000000000019d6689c085ae165831e93"
+        ]
+    }
   }
 }
 ```
+
+`chains` - A non-empty array of CAIP-2 chain IDs that the snap supports. This field is useful for a client in order to avoid unnecessary overhead.
 
 ### Snap Implementation
 

--- a/SIPS/sip-29.md
+++ b/SIPS/sip-29.md
@@ -135,6 +135,9 @@ type AssetDescription = {
     // Whether the asset is native to the chain.
     isNative: boolean;
 
+    // Whether the asset if fungible.
+    isFungible: boolean;
+
     // Base64 representation of the asset icon.
     iconBase64: string;
 


### PR DESCRIPTION
This PR tries to add a permission and handlers definition to the `SIP-29` (https://github.com/MetaMask/SIPs/pull/154). It also propose to use `asset` rather than the `token` denomination.