### PR TITLE
SIP-31: Introduce `onClientRequest` entrypoint

### DIFF
--- a/SIPS/sip-31.md
+++ b/SIPS/sip-31.md
@@ -86,7 +86,7 @@ type OnClientRequestArguments = {
 The type for an `onClientRequest` handler function’s return value is:
 
 ```typescript
-type OnClientRequestReturnValue = Json;
+type OnClientRequestResponse = Json;
 ```
 
 #### Behavior

--- a/SIPS/sip-31.md
+++ b/SIPS/sip-31.md
@@ -46,21 +46,48 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 in uppercase in this document are to be interpreted as described in [RFC
 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
-### `onClientRequest` Entrypoint
+### Snap Implementation
 
-Snaps MAY define an `onClientRequest` handler with the following signature:
+#### On Client Request
+
+This specification introduces to the Snap Platform a dedicated handler that
+Snaps MAY implement to process JSON-RPC requests originating exclusively from
+the client.
+
+Example:
 
 ```typescript
-type OnClientRequest = ({ request }: { request: JsonRpcRequest }) => Promise<Json>;
+import { OnClientRequestHandler } from "@metamask/snaps-sdk";
+
+export const onClientRequest: OnClientRequestHandler = async ({
+  request,
+}) => {
+  const result = /* Handle `request` */;
+  return result;
+};
 ```
 
-#### Parameters
+The type of the `onClientRequest` handler is:
 
-- `request: JsonRpcRequest` – A JSON-RPC request object.
+```typescript
+type OnClientRequestHandler = (
+  args: OnClientRequestArguments,
+) => Promise<OnClientRequestReturnValue>;
+```
 
-#### Returns
+The type for an `onClientRequest` handler function’s arguments is:
 
-A `Promise<Json>`, which resolves to any valid JSON structure.
+```typescript
+type OnClientRequestArguments = {
+  request: JsonRpcRequest;
+};
+```
+
+The type for an `onClientRequest` handler function’s return value is:
+
+```typescript
+type OnClientRequestReturnValue = Json;
+```
 
 #### Behavior
 

--- a/SIPS/sip-31.md
+++ b/SIPS/sip-31.md
@@ -9,35 +9,42 @@ created: 2025-03-19
 ## Abstract
 
 This proposal introduces a new entrypoint, `onClientRequest`, allowing Snaps to
-expose a handler that can only be called by MetaMask clients.
+expose a handler that can only be called by clients.
 
-While request `origin` is currently used to differentiate requests from
-MetaMask and dapps, this new entrypoint increases separation and minimizes the
-risks associated with `origin` spoofing or request routing bugs.
+While the request `origin` can currently be used to differentiate requests from
+clients and dapps, this new entrypoint increases separation and minimizes
+the risks associated with `origin` spoofing or request routing bugs.
 
 ## Motivation
 
 Currently, Snaps rely on the `origin` field of incoming requests to
-differentiate whether a request originates from MetaMask or an external dapp.
+differentiate whether a request originates from the client or an external dapp.
 However, this approach has potential risks:
 
 - **Origin Spoofing**: Bugs or vulnerabilities in request validation could
-  allow dApps to masquerade as MetaMask clients.
+  allow dapps to masquerade as clients.
 
-- **Unintended Exposure**: If a Snap processes requests without strict checks,
-  it may inadvertently handle dapp requests intended only for MetaMask.
+- **Unintended Exposure**: If a Snap processes requests without strict
+  validation, it may unintentionally expose to dapps methods that are meant
+  only for clients.
 
-- **Cleaner Separation**: Having a dedicated entrypoint for MetaMask requests
+- **Cleaner Separation**: Having a dedicated entrypoint for client requests
   enforces stricter request isolation at the API level.
 
 By introducing `onClientRequest`, we ensure that Snaps can define handlers
-exclusively accessible by MetaMask, reducing attack vectors and improving
-request security.
+exclusively accessible by clients, reducing attack vectors.
 
 ## Specification
 
-> This proposal introduces a new optional handler function, `onClientRequest`,
-> which a Snap can implement.
+This proposal introduces a new optional handler function, `onClientRequest`,
+which a Snap MAY implement.
+
+### Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" written
+in uppercase in this document are to be interpreted as described in [RFC
+2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 ### `onClientRequest` Entrypoint
 
@@ -57,26 +64,13 @@ A `Promise<JsonRpcResponse>`, which resolves to a JSON-RPC response object.
 
 #### Behavior
 
-- MetaMask MUST ensure that the request originates from a MetaMask client
-  before invoking `onClientRequest`.
+- Clients MUST ensure that they are the origin of a request before invoking
+  `onClientRequest`.
 
 - Requests from other origins MUST be rejected.
 
-- If a Snap does not implement `onClientRequest`, the default behavior is to
-  thrown an exception for any request, independent of the origin.
-
-### Language
-
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" written
-in uppercase in this document are to be interpreted as described in [RFC
-2119](https://www.ietf.org/rfc/rfc2119.txt)
-
-## Backwards compatibility
-
-Any SIPs that break backwards compatibility MUST include a section describing
-those incompatibilities and their severity. The SIP SHOULD describe how the
-author plans on proposes to deal with such these incompatibilities.
+- If a Snap does not implement `onClientRequest`, the client MUST throw an
+  exception for any request, regardless of the origin.
 
 ## Copyright
 

--- a/SIPS/sip-31.md
+++ b/SIPS/sip-31.md
@@ -51,7 +51,7 @@ in uppercase in this document are to be interpreted as described in [RFC
 Snaps MAY define an `onClientRequest` handler with the following signature:
 
 ```typescript
-type OnClientRequest = (request: JsonRpcRequest) => Promise<JsonRpcResponse>;
+type OnClientRequest = ({ request }: { request: JsonRpcRequest }) => Promise<JsonRpcResponse>;
 ```
 
 #### Parameters

--- a/SIPS/sip-31.md
+++ b/SIPS/sip-31.md
@@ -91,7 +91,7 @@ type OnClientRequestResponse = Json;
 
 #### Behavior
 
-- The client MUST ensure that they are the origin of a request before invoking
+- The client MUST ensure that it is the origin of a request before invoking
   `onClientRequest`.
 
 - Requests from other origins MUST be rejected.

--- a/SIPS/sip-31.md
+++ b/SIPS/sip-31.md
@@ -72,7 +72,7 @@ The type of the `onClientRequest` handler is:
 ```typescript
 type OnClientRequestHandler = (
   args: OnClientRequestArguments,
-) => Promise<OnClientRequestReturnValue>;
+) => Promise<OnClientRequestResponse>;
 ```
 
 The type for an `onClientRequest` handler function’s arguments is:

--- a/SIPS/sip-31.md
+++ b/SIPS/sip-31.md
@@ -1,0 +1,83 @@
+---
+sip: 31
+title: Client-only RPC Entrypoint
+status: Draft
+author: Daniel Rocha (@danroc)
+created: 2025-03-19
+---
+
+## Abstract
+
+This proposal introduces a new entrypoint, `onClientRequest`, allowing Snaps to
+expose a handler that can only be called by MetaMask clients.
+
+While request `origin` is currently used to differentiate requests from
+MetaMask and dapps, this new entrypoint increases separation and minimizes the
+risks associated with `origin` spoofing or request routing bugs.
+
+## Motivation
+
+Currently, Snaps rely on the `origin` field of incoming requests to
+differentiate whether a request originates from MetaMask or an external dapp.
+However, this approach has potential risks:
+
+- **Origin Spoofing**: Bugs or vulnerabilities in request validation could
+  allow dApps to masquerade as MetaMask clients.
+
+- **Unintended Exposure**: If a Snap processes requests without strict checks,
+  it may inadvertently handle dapp requests intended only for MetaMask.
+
+- **Cleaner Separation**: Having a dedicated entrypoint for MetaMask requests
+  enforces stricter request isolation at the API level.
+
+By introducing `onClientRequest`, we ensure that Snaps can define handlers
+exclusively accessible by MetaMask, reducing attack vectors and improving
+request security.
+
+## Specification
+
+> This proposal introduces a new optional handler function, `onClientRequest`,
+> which a Snap can implement.
+
+### `onClientRequest` Entrypoint
+
+Snaps MAY define an `onClientRequest` handler with the following signature:
+
+```typescript
+type OnClientRequest = (request: JsonRpcRequest) => Promise<JsonRpcResponse>;
+```
+
+#### Parameters
+
+- `request: JsonRpcRequest` – A JSON-RPC request object.
+
+#### Returns
+
+A `Promise<JsonRpcResponse>`, which resolves to a JSON-RPC response object.
+
+#### Behavior
+
+- MetaMask MUST ensure that the request originates from a MetaMask client
+  before invoking `onClientRequest`.
+
+- Requests from other origins MUST be rejected.
+
+- If a Snap does not implement `onClientRequest`, the default behavior is to
+  thrown an exception for any request, independent of the origin.
+
+### Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" written
+in uppercase in this document are to be interpreted as described in [RFC
+2119](https://www.ietf.org/rfc/rfc2119.txt)
+
+## Backwards compatibility
+
+Any SIPs that break backwards compatibility MUST include a section describing
+those incompatibilities and their severity. The SIP SHOULD describe how the
+author plans on proposes to deal with such these incompatibilities.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE).

--- a/SIPS/sip-31.md
+++ b/SIPS/sip-31.md
@@ -51,7 +51,7 @@ in uppercase in this document are to be interpreted as described in [RFC
 Snaps MAY define an `onClientRequest` handler with the following signature:
 
 ```typescript
-type OnClientRequest = ({ request }: { request: JsonRpcRequest }) => Promise<JsonRpcResponse>;
+type OnClientRequest = ({ request }: { request: JsonRpcRequest }) => Promise<Json>;
 ```
 
 #### Parameters

--- a/SIPS/sip-31.md
+++ b/SIPS/sip-31.md
@@ -22,7 +22,7 @@ differentiate whether a request originates from the client, another
 Snap, or an external dapp. However, this approach has potential risks:
 
 - **Origin Spoofing**: Bugs or vulnerabilities in request validation could
-  allow dapps to masquerade as the client.
+  allow dapps to masquerade as the client or a different dapp.
 
 - **Unintended Exposure**: If a Snap processes requests without strict
   validation, it may unintentionally expose methods to dapps or other Snaps

--- a/SIPS/sip-31.md
+++ b/SIPS/sip-31.md
@@ -60,7 +60,7 @@ type OnClientRequest = ({ request }: { request: JsonRpcRequest }) => Promise<Jso
 
 #### Returns
 
-A `Promise<JsonRpcResponse>`, which resolves to a JSON-RPC response object.
+A `Promise<Json>`, which resolves to any valid JSON structure.
 
 #### Behavior
 

--- a/SIPS/sip-31.md
+++ b/SIPS/sip-31.md
@@ -9,7 +9,7 @@ created: 2025-03-19
 ## Abstract
 
 This proposal introduces a new entrypoint, `onClientRequest`, allowing Snaps to
-expose a handler that can only be called by clients.
+expose a handler that can only be called by the client.
 
 While the request `origin` can currently be used to differentiate requests from
 clients and dapps, this new entrypoint increases separation and minimizes
@@ -18,25 +18,25 @@ the risks associated with `origin` spoofing or request routing bugs.
 ## Motivation
 
 Currently, Snaps rely on the `origin` field of incoming requests to
-differentiate whether a request originates from the client or an external dapp.
-However, this approach has potential risks:
+differentiate whether a request originates from the client, another
+Snap, or an external dapp. However, this approach has potential risks:
 
 - **Origin Spoofing**: Bugs or vulnerabilities in request validation could
-  allow dapps to masquerade as clients.
+  allow dapps to masquerade as the client.
 
 - **Unintended Exposure**: If a Snap processes requests without strict
-  validation, it may unintentionally expose to dapps methods that are meant
-  only for clients.
+  validation, it may unintentionally expose methods to dapps or other Snaps
+  that are meant only for the client.
 
 - **Cleaner Separation**: Having a dedicated entrypoint for client requests
   enforces stricter request isolation at the API level.
 
 By introducing `onClientRequest`, we ensure that Snaps can define handlers
-exclusively accessible by clients, reducing attack vectors.
+exclusively accessible by the client, reducing potential attack vectors.
 
 ## Specification
 
-This proposal introduces a new optional handler function, `onClientRequest`,
+This proposal introduces a new OPTIONAL handler function, `onClientRequest`,
 which a Snap MAY implement.
 
 ### Language
@@ -64,13 +64,13 @@ A `Promise<JsonRpcResponse>`, which resolves to a JSON-RPC response object.
 
 #### Behavior
 
-- Clients MUST ensure that they are the origin of a request before invoking
+- The client MUST ensure that they are the origin of a request before invoking
   `onClientRequest`.
 
 - Requests from other origins MUST be rejected.
 
 - If a Snap does not implement `onClientRequest`, the client MUST throw an
-  exception for any request, regardless of the origin.
+  exception for requests directed to that entrypoint, regardless of the origin.
 
 ## Copyright
 


### PR DESCRIPTION
This proposal introduces a new entrypoint, `onClientRequest`, allowing Snaps to expose a handler that can only be called by clients.

While the request `origin` can currently be used to differentiate requests from clients and dapps, this new entrypoint increases separation and minimizes the risks associated with `origin` spoofing or request routing bugs.