### PR TITLE
Fix example in SIP-32

### DIFF
--- a/SIPS/sip-32.md
+++ b/SIPS/sip-32.md
@@ -72,7 +72,7 @@ await snap.request({
   params: {
     event: {
       category: 'Accounts',
-      name: 'Account Added',
+      event: 'Account Added',
       properties: {
         message: 'Snap account added',
       },


### PR DESCRIPTION
The field should be `event` and not `name`.