### PR TITLE
SIP-33: read contacts

### DIFF
--- a/SIPS/sip-33.md
+++ b/SIPS/sip-33.md
@@ -2,7 +2,7 @@
 sip: 33
 title: Contacts API for Snaps
 status: Draft
-author: Fabio Bozzo <fabio.bozzo@consensys.net>
+author: Fabio Bozzo (@fabiobozzo)
 created: 2025-04-04
 ---
 


### PR DESCRIPTION
This PR introduces `SIP-33`, which proposes a new RPC method `snap_getContacts` that allows Snaps to access contacts from a user's MetaMask address book. 

Key features:
- Introduces a new permission snap_getContacts that grants read-only access to contacts
- Returns contact data including name, address, and optional metadata (future proof)
- Enables user-friendly workflows by letting Snaps leverage existing contacts, instead of custom per-Snap address books managed via `snap_manageState`

This feature would benefit users by eliminating the need to manually copy/paste addresses and allowing Snaps to provide more personalized experiences like recipient selection from contacts, contact-based notifications, and improved transaction insights. The implementation focuses on security and privacy, ensuring users have clear visibility into what contact information is being shared.