### PR TITLE
SIP-32: Remove unnecessary field of event payload

### DIFF
--- a/SIPS/sip-32.md
+++ b/SIPS/sip-32.md
@@ -47,18 +47,11 @@ pre-installed.
 #### Parameters
 
 - `event` - Event object to be tracked.
-  - `category: string` - The category to associate the event.
-
-  - `event: string` - The name of the event to track.
+  - `name: string` - The name of the event to track.
 
   - `properties: Record<string, Json>` - (**Optional**) Custom values to track.
     The client MUST enforce that all keys in this object are in the
     `snake_case` format.
-
-  - `sensitiveProperties: Record<string, Json>` - (**Optional**) Sensitive
-    values to track. These properties will be sent in an additional event that
-    excludes the user's `metaMetricsId`. The client MUST enforce that all keys
-    in this object are in the `snake_case` format.
 
 #### Returns
 
@@ -71,13 +64,9 @@ await snap.request({
   method: 'snap_trackEvent',
   params: {
     event: {
-      category: 'Accounts',
-      event: 'Account Added',
+      name: 'Account Added',
       properties: {
         message: 'Snap account added',
-      },
-      sensitiveProperties: {
-        account_type: 'Hardware Wallet',
       },
     },
   },

--- a/SIPS/sip-32.md
+++ b/SIPS/sip-32.md
@@ -47,11 +47,16 @@ pre-installed.
 #### Parameters
 
 - `event` - Event object to be tracked.
-  - `name: string` - The name of the event to track.
+  - `event: string` - The name of the event to track.
 
   - `properties: Record<string, Json>` - (**Optional**) Custom values to track.
     The client MUST enforce that all keys in this object are in the
     `snake_case` format.
+
+  - `sensitiveProperties: Record<string, Json>` - (**Optional**) Sensitive
+    values to track. These properties will be sent in an additional event that
+    excludes the user's `metaMetricsId`. The client MUST enforce that all keys
+    in this object are in the `snake_case` format.
 
 #### Returns
 
@@ -64,9 +69,12 @@ await snap.request({
   method: 'snap_trackEvent',
   params: {
     event: {
-      name: 'Account Added',
+      event: 'Account Added',
       properties: {
         message: 'Snap account added',
+      },
+      sensitiveProperties: {
+        account_type: 'Hardware Wallet',
       },
     },
   },


### PR DESCRIPTION
The PR remove `category` from the `event` object. @worldlyjohn pointed out that it's legacy and shouldn't be used anymore.