### PR TITLE
fix: Reduce fetch calls

### DIFF
--- a/SIPS/sip-32.md
+++ b/SIPS/sip-32.md
@@ -13,7 +13,7 @@ This Snap Improvement Proposal (SIP) introduces a new method,
 through the client. The client will determine how to handle these events.
 
 This feature enables Snaps to utilize the existing client infrastructure for
-event tracking while maintaining user privacy. Temp
+event tracking while maintaining user privacy. Temp2
 
 ## Motivation
 

--- a/SIPS/sip-32.md
+++ b/SIPS/sip-32.md
@@ -13,7 +13,7 @@ This Snap Improvement Proposal (SIP) introduces a new method,
 through the client. The client will determine how to handle these events.
 
 This feature enables Snaps to utilize the existing client infrastructure for
-event tracking while maintaining user privacy.
+event tracking while maintaining user privacy. Temp
 
 ## Motivation
 

--- a/SIPS/sip-32.md
+++ b/SIPS/sip-32.md
@@ -13,7 +13,7 @@ This Snap Improvement Proposal (SIP) introduces a new method,
 through the client. The client will determine how to handle these events.
 
 This feature enables Snaps to utilize the existing client infrastructure for
-event tracking while maintaining user privacy. Temp2
+event tracking while maintaining user privacy.
 
 ## Motivation
 

--- a/tools/validate/package.json
+++ b/tools/validate/package.json
@@ -26,9 +26,9 @@
     "typescript": "^4.7.3"
   },
   "dependencies": {
+    "async-mutex": "^0.5.0",
     "chalk": "^5.0.1",
     "debug": "^4.3.4",
-    "fetch-retry": "^6.0.0",
     "glob": "^8.0.3",
     "is-valid-path": "^0.1.1",
     "remark-frontmatter": "^4.0.1",

--- a/tools/validate/package.json
+++ b/tools/validate/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "chalk": "^5.0.1",
     "debug": "^4.3.4",
+    "fetch-retry": "^6.0.0",
     "glob": "^8.0.3",
     "is-valid-path": "^0.1.1",
     "remark-frontmatter": "^4.0.1",

--- a/tools/validate/src/rules/bad-link.ts
+++ b/tools/validate/src/rules/bad-link.ts
@@ -44,8 +44,7 @@ const fetchCache = new Map<string, Promise<Response>>();
 const fetchFunction = retryFetch(global.fetch, {
   retries: 3,
   retryOn: [429, 503],
-  // Exponential backoff
-  retryDelay: (attempt) => Math.pow(2, attempt) * 1000,
+  retryDelay: 10000,
 });
 
 const rule = lintRule<Root>("sip:bad-link", async (tree, file) => {

--- a/tools/validate/src/rules/bad-link.ts
+++ b/tools/validate/src/rules/bad-link.ts
@@ -44,7 +44,7 @@ const fetchCache = new Map<string, Promise<Response>>();
 const fetchFunction = retryFetch(global.fetch, {
   retries: 3,
   retryOn: [429, 503],
-  retryDelay: 10000,
+  retryDelay: 25000,
 });
 
 const rule = lintRule<Root>("sip:bad-link", async (tree, file) => {

--- a/tools/validate/src/rules/bad-link.ts
+++ b/tools/validate/src/rules/bad-link.ts
@@ -39,10 +39,10 @@ function isExternal(url: string | URL): boolean {
   return !isLocal(url);
 }
 
-const fetchCache = new Map<string, Response>();
+const fetchCache = new Map<string, Promise<Response>>();
 
 const fetchFunction = retryFetch(global.fetch, {
-  retries: 5,
+  retries: 3,
   retryOn: [429, 503],
   // Exponential backoff
   retryDelay: (attempt) => Math.pow(2, attempt) * 1000,
@@ -60,7 +60,7 @@ const rule = lintRule<Root>("sip:bad-link", async (tree, file) => {
           debug("Fetch cached", url);
           return fetchCache.get(url)!;
         }
-        const response = await fetchFunction(...args);
+        const response = fetchFunction(...args);
         fetchCache.set(url, response);
         return response;
       } catch (e) {

--- a/tools/validate/src/rules/bad-link.ts
+++ b/tools/validate/src/rules/bad-link.ts
@@ -56,12 +56,13 @@ const rule = lintRule<Root>("sip:bad-link", async (tree, file) => {
     ): ReturnType<typeof fetchFunction> => {
       try {
         const url = args[0] as string;
-        if (fetchCache.has(url)) {
-          debug("Fetch cached", url);
-          return fetchCache.get(url)!;
+        const options = args[1] as RequestInit;
+        const key = `${options?.method ?? 'GET'}-${url}`;
+        if (fetchCache.has(key)) {
+          return fetchCache.get(key)!;
         }
-        const response = fetchFunction(...args);
-        fetchCache.set(url, response);
+        const response = fetchFunction(url, options);
+        fetchCache.set(key, response);
         return response;
       } catch (e) {
         const url = args[0].toString();

--- a/yarn.lock
+++ b/yarn.lock
@@ -577,6 +577,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fetch-retry@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "fetch-retry@npm:6.0.0"
+  checksum: 10/0c8d3082e2d76fff2df75adef6280bc854bc36fd3ef38506674f0216d0d819e2efd14da7477d3f1732415aea1d2cfde7cd3e1aeae46f45f2adbfc5133296e8de
+  languageName: node
+  linkType: hard
+
 "foreground-child@npm:^3.1.0":
   version: 3.3.0
   resolution: "foreground-child@npm:3.3.0"
@@ -2371,6 +2378,7 @@ __metadata:
     "@types/yargs": "npm:^17.0.10"
     chalk: "npm:^5.0.1"
     debug: "npm:^4.3.4"
+    fetch-retry: "npm:^6.0.0"
     glob: "npm:^8.0.3"
     is-valid-path: "npm:^0.1.1"
     mdast: "npm:^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1975,7 +1975,6 @@ __metadata:
   dependencies:
     "@lavamoat/allow-scripts": "npm:^3.3.1"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
-    async-mutex: "npm:^0.5.0"
   languageName: unknown
   linkType: soft
 
@@ -2386,6 +2385,7 @@ __metadata:
     "@types/node": "npm:^17.0.41"
     "@types/unist": "npm:^2.0.6"
     "@types/yargs": "npm:^17.0.10"
+    async-mutex: "npm:^0.5.0"
     chalk: "npm:^5.0.1"
     debug: "npm:^4.3.4"
     glob: "npm:^8.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -295,6 +295,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"async-mutex@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "async-mutex@npm:0.5.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/4c6bfce1cc9cd43f723c4d96403ac5f4757f885c953b839cde6956ec8817ff39623b82d67614de10c7933e21626925882fb9bac367db7d15d7cb4f84228722c9
+  languageName: node
+  linkType: hard
+
 "bail@npm:^2.0.0":
   version: 2.0.2
   resolution: "bail@npm:2.0.2"
@@ -574,13 +583,6 @@ __metadata:
   dependencies:
     format: "npm:^0.2.0"
   checksum: 10/c9b30f47d95769177130a9409976a899ed31eb598450fbad5b0d39f2f5f56d5f4a9ff9257e0bee8407cb0fc3ce37165657888c6aa6d78472e403893104329b72
-  languageName: node
-  linkType: hard
-
-"fetch-retry@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "fetch-retry@npm:6.0.0"
-  checksum: 10/0c8d3082e2d76fff2df75adef6280bc854bc36fd3ef38506674f0216d0d819e2efd14da7477d3f1732415aea1d2cfde7cd3e1aeae46f45f2adbfc5133296e8de
   languageName: node
   linkType: hard
 
@@ -1973,6 +1975,7 @@ __metadata:
   dependencies:
     "@lavamoat/allow-scripts": "npm:^3.3.1"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
+    async-mutex: "npm:^0.5.0"
   languageName: unknown
   linkType: soft
 
@@ -2198,6 +2201,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:^2.4.0":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7
+  languageName: node
+  linkType: hard
+
 "type-fest@npm:4.30.0":
   version: 4.30.0
   resolution: "type-fest@npm:4.30.0"
@@ -2378,7 +2388,6 @@ __metadata:
     "@types/yargs": "npm:^17.0.10"
     chalk: "npm:^5.0.1"
     debug: "npm:^4.3.4"
-    fetch-retry: "npm:^6.0.0"
     glob: "npm:^8.0.3"
     is-valid-path: "npm:^0.1.1"
     mdast: "npm:^3.0.0"


### PR DESCRIPTION
We were making a wild amount of requests to the links used in SIPs during validation and hit rate-limits. This PR attempts to reduce the amount of fetch calls we do by using a cache and a semaphore to queue some of the requests. However, this was not enough to pass CI consistently as we still sometimes may hit 429s, therefore this PR also treats links that return 429 as valid.